### PR TITLE
Add build as script target to run SASS build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "gulp-sass": "^2.3.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "gulp sass"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes #9, now we can avoid installing `gulp` separately and simply do `npm run build` after doing `npm install` whenever we want to generate CSS file from SCSS changes. :confetti_ball: 
